### PR TITLE
fixes importing of JSON call logs on older phones (concerns issue #3)

### DIFF
--- a/app/src/main/java/com/github/tmo1/sms_ie/MainActivity.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/MainActivity.kt
@@ -313,7 +313,8 @@ class MainActivity : AppCompatActivity(), ConfirmWipeFragment.NoticeDialogListen
         if (checkReadWriteCallLogPermissions(this)) {
             val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
                 addCategory(Intent.CATEGORY_OPENABLE)
-                type = "application/json"
+                type =
+                    if (SDK_INT < 29) "*/*" else "application/json" //see https://github.com/tmo1/sms-ie/issues/3#issuecomment-900518890
             }
             startActivityForResult(intent, IMPORT_CALL_LOG)
         } else {


### PR DESCRIPTION
Issue #3 concerns older Android versions not recognizing the JSON MIME type. The original fix only solved the problem for message files. My commit applies the fix for call logs as well.