### PR TITLE
Try to run scheduled exports in foreground service where possible

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.WRITE_CONTACTS" />
     <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-permission android:name="android.permission.WRITE_CALL_LOG" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <application
         android:allowBackup="true"
@@ -60,6 +63,11 @@
                 <data android:scheme="mmsto" />
             </intent-filter>
         </service>
+
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="specialUse"
+            tools:node="merge" />
 
         <activity
             android:name=".ComposeSmsActivity"

--- a/app/src/main/java/com/github/tmo1/sms_ie/SettingsActivity.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/SettingsActivity.kt
@@ -22,20 +22,28 @@
 
 package com.github.tmo1.sms_ie
 
+import android.annotation.SuppressLint
+import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
+import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
+import android.os.PowerManager
+import android.provider.Settings
 import android.util.Log
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
 
 const val REQUEST_EXPORT_FOLDER = 4
 const val EXPORT_DIR = "export_dir"
+const val DISABLE_BATTERY_OPTIMIZATIONS = "disable_battery_optimizations"
 const val EXPORT_WORK_TAG = "export"
 
 class SettingsActivity : AppCompatActivity() {
@@ -63,7 +71,16 @@ class SettingsActivity : AppCompatActivity() {
             findPreference<Preference>(EXPORT_DIR)
                 ?: error("Missing export directory preference!")
         }
+        private val disableBattOptPreference: SwitchPreferenceCompat by lazy {
+            findPreference<SwitchPreferenceCompat>(DISABLE_BATTERY_OPTIMIZATIONS)
+                ?: error("Missing disable battery optimizations preference!")
+        }
+        private val requestDisableBattOpt =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+                updateBatteryOptimizationState()
+            }
 
+        @SuppressLint("BatteryLife")
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             setPreferencesFromResource(R.xml.root_preferences, rootKey)
             /* The time picker is somehow calling 'android.widget.TimePicker.setHour', which was added in API level 23,
@@ -91,6 +108,23 @@ class SettingsActivity : AppCompatActivity() {
             }
             updateExportDirPreferenceSummary()
 
+            if (SDK_INT >= Build.VERSION_CODES.M) {
+                disableBattOptPreference.setOnPreferenceChangeListener { _, newValue ->
+                    if (newValue == true) {
+                        requestDisableBattOpt.launch(Intent(
+                            Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+                            Uri.fromParts("package", requireContext().packageName, null),
+                        ))
+                    } else {
+                        // There is no API to request battery optimizations to be re-enabled, so
+                        // send the user to Android's Settings page for them to do it manually.
+                        startActivity(Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS))
+                    }
+
+                    false
+                }
+            }
+
             // see: https://stackoverflow.com/questions/26242581/call-method-after-changing-preferences-in-android
             // https://stackoverflow.com/questions/7020446/android-registeronsharedpreferencechangelistener-causes-crash-in-a-custom-view#7021068
             // https://stackoverflow.com/questions/66449883/kotlin-onsharedpreferencechangelistener
@@ -101,6 +135,15 @@ class SettingsActivity : AppCompatActivity() {
                     }
                 }
             prefs?.registerOnSharedPreferenceChangeListener(prefListener)
+        }
+
+        override fun onStart() {
+            super.onStart()
+
+            // Changing the option does not reload the activity.
+            if (SDK_INT >= Build.VERSION_CODES.M) {
+                updateBatteryOptimizationState()
+            }
         }
 
         // from: https://old.black/2020/09/18/building-custom-timepicker-dialog-preference-in-android-kotlin/
@@ -168,8 +211,17 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         private fun updateExportDirPreferenceSummary() {
-            findPreference<Preference>(EXPORT_DIR)?.summary =
-                Uri.decode(prefs?.getString(EXPORT_DIR, ""))
+            targetDirPreference.summary = Uri.decode(prefs?.getString(EXPORT_DIR, ""))
+        }
+
+        private fun updateBatteryOptimizationState() {
+            if (SDK_INT >= Build.VERSION_CODES.M) {
+                val context = requireContext()
+                val pm: PowerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+                disableBattOptPreference.isChecked = pm.isIgnoringBatteryOptimizations(context.packageName)
+            } else {
+                disableBattOptPreference.isVisible = false
+            }
         }
     }
 }

--- a/app/src/main/java/com/github/tmo1/sms_ie/SettingsActivity.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/SettingsActivity.kt
@@ -97,16 +97,17 @@ class SettingsActivity : AppCompatActivity() {
                 if (preferenceCategory != null && preferenceScreen != null) {
                         preferenceScreen.removePreference(preferenceCategory)
                 }
-            }
-            targetDirPreference.setOnPreferenceClickListener {
-                val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
-                    //addCategory(Intent.CATEGORY_OPENABLE)
-                    //putExtra(DocumentsContract.EXTRA_INITIAL_URI, "")
+            } else {
+                targetDirPreference.setOnPreferenceClickListener {
+                    val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+                        //addCategory(Intent.CATEGORY_OPENABLE)
+                        //putExtra(DocumentsContract.EXTRA_INITIAL_URI, "")
+                    }
+                    startActivityForResult(intent, REQUEST_EXPORT_FOLDER)
+                    true
                 }
-                startActivityForResult(intent, REQUEST_EXPORT_FOLDER)
-                true
+                updateExportDirPreferenceSummary()
             }
-            updateExportDirPreferenceSummary()
 
             if (SDK_INT >= Build.VERSION_CODES.M) {
                 disableBattOptPreference.setOnPreferenceChangeListener { _, newValue ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,7 @@
     <string name="include_binary_data">Include binary MMS data</string>
     <string name="channel_name">notification_channel</string>
     <string name="channel_description">Notification Channel</string>
+    <string name="scheduled_export_executing">Scheduled export executing</string>
     <string name="scheduled_export_executed">Scheduled export executed</string>
     <string name="scheduled_export_success">%1$d SMS(s), %2$d MMS(s), %3$d calls, and %4$d contacts exported.</string>
     <string name="scheduled_export_failure">Export unsuccessful — see logcat for more details.</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -44,6 +44,13 @@
             app:dependency="schedule_export" />
 
         <SwitchPreferenceCompat
+            android:key="disable_battery_optimizations"
+            android:title="Disable battery optimizations"
+            android:summary="Required on Android 14+ when exporting many items."
+            android:persistent="false"
+            app:dependency="schedule_export" />
+
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="delete_old_exports"
             android:title="Delete old exports"


### PR DESCRIPTION
Android 14 introduced a change in the `CachedAppOptimizer` component that kills apps that perform too many binder transactions in the background [1]. This can happen where there are many messages to export (2000 or so from empirical testing).

This restriction does not apply to foreground services, so this commit adds support for opportunistically running `ExportWorker` inside `WorkManager`'s foreground service. Unfortunately, on Android 12+, this is not allowed by default because `ExportWorker`'s startup method of using a delay on a `OneTimeWorkRequestBuilder` is not one of the exemptions for running a foreground service.

To allow a foreground service to run, the user must disable Android's battery optimizations for the app. This commit adds a toggle to do so in the sms-ie's own settings so the user doesn't need to dig into Android's Settings to find the option. If foreground service access is not available (because eg. battery optimizations are enabled or the app is running on an old version of Android), then the worker will fall back to running in a plain old background service like before.

[1] https://android.googlesource.com/platform/frameworks/base.git/+/71d75c09b9a06732a6edb4d1488d2aa3eb779e14%5E%21/
[2] https://developer.android.com/guide/components/foreground-services#background-start-restriction-exemptions

Fixes: #129