### PR TITLE
Add titlebar in about page

### DIFF
--- a/app/src/main/java/com/github/tmo1/sms_ie/AboutActivity.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/AboutActivity.kt
@@ -30,5 +30,13 @@ class AboutActivity : AppCompatActivity() {
         setContentView(R.layout.activity_about)
         val aboutText: TextView = findViewById(R.id.aboutText)
         aboutText.text = getString(R.string.app_about_text, BuildConfig.VERSION_NAME)
+        setSupportActionBar(findViewById(R.id.toolbar))
+        supportActionBar?.setTitle(R.string.about)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        finish()
+        return true
     }
 }

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -18,16 +18,23 @@
   ~ along with SMS Import / Export.  If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".AboutActivity">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <include layout="@layout/app_bar" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        tools:context=".AboutActivity">
 
     <TextView
         android:id="@+id/aboutText"
@@ -158,4 +165,6 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-</ScrollView>
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/app_bar.xml
+++ b/app/src/main/res/layout/app_bar.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/actionBarSize"
+    android:background="?attr/colorPrimary"
+    android:minHeight="?attr/actionBarSize"
+    android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
+    app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+    app:titleTextAppearance="@style/TextAppearance.Widget.AppCompat.Toolbar.Title"
+    app:subtitleTextAppearance="@style/TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />


### PR DESCRIPTION
This addition will provide easy navigation back to the main menu, as well as improve the user experience and consistent design.

* Before:

![before](https://github.com/tmo1/sms-ie/assets/31443074/bac696f6-d30e-4b0d-9f5e-5f7da4450c3f)

* After:

![after](https://github.com/tmo1/sms-ie/assets/31443074/f2904ed6-1510-460e-9478-050043bf1f42)

