### PR TITLE
fix: import crashes on miui, #103

### DIFF
--- a/app/src/main/java/com/github/tmo1/sms_ie/ImportExport.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/ImportExport.kt
@@ -42,6 +42,9 @@ import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
 
 fun checkReadSMSContactsPermissions(appContext: Context): Boolean {
     return ContextCompat.checkSelfPermission(
@@ -177,5 +180,17 @@ suspend fun displayError(appContext: Context, e: Exception?, title: String, mess
         .setCancelable(false).setNeutralButton("Okay", null)
     withContext(Dispatchers.Main) {
         errorBox.show()
+    }
+}
+
+// slightly adapted solution from https://gist.github.com/starry-shivam/901267c26eb030eb3faf1ccd4d2bdd32
+fun isMiui(): Boolean {
+    try {
+        val inputStream = Runtime.getRuntime()
+            .exec("getprop ro.miui.ui.version.code").inputStream
+        val miuiVer = BufferedReader(InputStreamReader(inputStream)).readLine()
+        return miuiVer.isNotEmpty()
+    } catch(e: IOException) {
+        return false
     }
 }

--- a/app/src/main/java/com/github/tmo1/sms_ie/ImportExport.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/ImportExport.kt
@@ -42,9 +42,6 @@ import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.BufferedReader
-import java.io.IOException
-import java.io.InputStreamReader
 
 fun checkReadSMSContactsPermissions(appContext: Context): Boolean {
     return ContextCompat.checkSelfPermission(
@@ -180,17 +177,5 @@ suspend fun displayError(appContext: Context, e: Exception?, title: String, mess
         .setCancelable(false).setNeutralButton("Okay", null)
     withContext(Dispatchers.Main) {
         errorBox.show()
-    }
-}
-
-// slightly adapted solution from https://gist.github.com/starry-shivam/901267c26eb030eb3faf1ccd4d2bdd32
-fun isMiui(): Boolean {
-    try {
-        val inputStream = Runtime.getRuntime()
-            .exec("getprop ro.miui.ui.version.code").inputStream
-        val miuiVer = BufferedReader(InputStreamReader(inputStream)).readLine()
-        return miuiVer.isNotEmpty()
-    } catch(e: IOException) {
-        return false
     }
 }

--- a/app/src/main/java/com/github/tmo1/sms_ie/ImportExportMessages.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/ImportExportMessages.kt
@@ -289,6 +289,7 @@ suspend fun importMessages(
 ): MessageTotal {
     val prefs = PreferenceManager.getDefaultSharedPreferences(appContext)
     val deduplication = prefs.getBoolean("deduplication", false)
+    val isMiui = isMiui()
     return withContext(Dispatchers.IO) {
         val totals = MessageTotal()
         // get column names of local SMS, MMS, and MMS part tables
@@ -404,6 +405,11 @@ suspend fun importMessages(
                                                 return@JSONLine
                                             }
                                         }
+                                    }
+                                    // https://github.com/tmo1/sms-ie/issues/103
+                                    if (isMiui) {
+                                        messageJSON.remove("deleted")
+                                        messageJSON.remove("sync_state")
                                     }
                                     messageJSON.keys().forEach { key ->
                                         if (key in smsColumns) messageMetadata.put(


### PR DESCRIPTION
when device has miui, it now removes the "deleted" and "sync_state" fields

i've tested it on my device and it works now