### PR TITLE
ImportExportWorker: Save logcat of latest operation

### DIFF
--- a/app/src/main/java/com/github/tmo1/sms_ie/MainActivity.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/MainActivity.kt
@@ -263,8 +263,11 @@ class MainActivity : AppCompatActivity(), ConfirmWipeFragment.NoticeDialogListen
                             // detailed message will be shown in the dialog box.
                             statusReportText.text = failure.title
 
-                            ErrorMessageFragment.newInstance(failure.title, failure.message)
-                                .show(supportFragmentManager, "error")
+                            ErrorMessageFragment.newInstance(
+                                failure.title,
+                                failure.message,
+                                failure.savedLogcat,
+                            ).show(supportFragmentManager, "error")
                         }
                         // Cancelled work can occur when changing scheduled export settings or when
                         // the user explicitly cancels a running operation. We want both to be
@@ -478,9 +481,14 @@ class MainActivity : AppCompatActivity(), ConfirmWipeFragment.NoticeDialogListen
 
 class ErrorMessageFragment : DialogFragment() {
     companion object {
-        fun newInstance(title: String, message: String) = ErrorMessageFragment().apply {
-            arguments = bundleOf("title" to title, "message" to message)
-        }
+        fun newInstance(title: String, message: String, savedLogcat: Boolean) =
+            ErrorMessageFragment().apply {
+                arguments = bundleOf(
+                    "title" to title,
+                    "message" to message,
+                    "saved_logcat" to savedLogcat,
+                )
+            }
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
@@ -488,31 +496,36 @@ class ErrorMessageFragment : DialogFragment() {
             .setTitle(requireArguments().getString("title"))
             .setMessage(requireArguments().getString("message"))
             .setPositiveButton(android.R.string.ok) { _, _ -> }
-            .setNeutralButton(R.string.open_log_dir) { _, _ ->
-                // The external files directory (/sdcard/Android/data/<package>/files) is only
-                // readable via USB (adb or mtp) or via the system file manager (DocumentsUI) in
-                // recent versions of Android. This intent will open the system file manager to the
-                // proper directory. Unfortunately, passing it a file:// URI directly will fail with
-                // FileUriExposedException. We need to manually construct a SAF content:// URI.
-                // While these constants are not documented, since they are part of content:// URIs,
-                // Android realistically can't ever change them without revoking permissions to
-                // files that apps have already been granted access to. Android's own tests also
-                // hardcode them.
-                val intent = Intent(Intent.ACTION_VIEW).apply {
-                    val appExternalDir = requireContext().getExternalFilesDir(null)!!
-                    val globalExternalDir = Environment.getExternalStorageDirectory()
-                    val relPath = appExternalDir.relativeTo(globalExternalDir)
+            .apply {
+                if (requireArguments().getBoolean("saved_logcat")) {
+                    setNeutralButton(R.string.open_log_dir) { _, _ ->
+                        // The external files directory (/sdcard/Android/data/<package>/files) is
+                        // only readable via USB (adb or mtp) or via the system file manager
+                        // (DocumentsUI) in recent versions of Android. This intent will open the
+                        // system file manager to the proper directory. Unfortunately, passing it a
+                        // file:// URI directly will fail with FileUriExposedException. We need to
+                        // manually construct a SAF content:// URI. While these constants are not
+                        // documented, since they are part of content:// URIs, Android realistically
+                        // can't ever change them without revoking permissions to files that apps
+                        // have already been granted access to. Android's own tests also hardcode
+                        // them.
+                        val intent = Intent(Intent.ACTION_VIEW).apply {
+                            val appExternalDir = requireContext().getExternalFilesDir(null)!!
+                            val globalExternalDir = Environment.getExternalStorageDirectory()
+                            val relPath = appExternalDir.relativeTo(globalExternalDir)
 
-                    setDataAndType(
-                        DocumentsContract.buildDocumentUri(
-                            "com.android.externalstorage.documents",
-                            "primary:$relPath",
-                        ),
-                        "vnd.android.document/directory",
-                    )
+                            setDataAndType(
+                                DocumentsContract.buildDocumentUri(
+                                    "com.android.externalstorage.documents",
+                                    "primary:$relPath",
+                                ),
+                                "vnd.android.document/directory",
+                            )
+                        }
+
+                        startActivity(intent)
+                    }
                 }
-
-                startActivity(intent)
             }
             .create()
 }

--- a/app/src/main/java/com/github/tmo1/sms_ie/MainActivity.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/MainActivity.kt
@@ -34,6 +34,8 @@ import android.net.Uri
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
+import android.os.Environment
+import android.provider.DocumentsContract
 import android.provider.Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS
 import android.provider.Telephony
 import android.view.Menu
@@ -486,6 +488,32 @@ class ErrorMessageFragment : DialogFragment() {
             .setTitle(requireArguments().getString("title"))
             .setMessage(requireArguments().getString("message"))
             .setPositiveButton(android.R.string.ok) { _, _ -> }
+            .setNeutralButton(R.string.open_log_dir) { _, _ ->
+                // The external files directory (/sdcard/Android/data/<package>/files) is only
+                // readable via USB (adb or mtp) or via the system file manager (DocumentsUI) in
+                // recent versions of Android. This intent will open the system file manager to the
+                // proper directory. Unfortunately, passing it a file:// URI directly will fail with
+                // FileUriExposedException. We need to manually construct a SAF content:// URI.
+                // While these constants are not documented, since they are part of content:// URIs,
+                // Android realistically can't ever change them without revoking permissions to
+                // files that apps have already been granted access to. Android's own tests also
+                // hardcode them.
+                val intent = Intent(Intent.ACTION_VIEW).apply {
+                    val appExternalDir = requireContext().getExternalFilesDir(null)!!
+                    val globalExternalDir = Environment.getExternalStorageDirectory()
+                    val relPath = appExternalDir.relativeTo(globalExternalDir)
+
+                    setDataAndType(
+                        DocumentsContract.buildDocumentUri(
+                            "com.android.externalstorage.documents",
+                            "primary:$relPath",
+                        ),
+                        "vnd.android.document/directory",
+                    )
+                }
+
+                startActivity(intent)
+            }
             .create()
 }
 

--- a/app/src/main/java/com/github/tmo1/sms_ie/SettingsActivity.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/SettingsActivity.kt
@@ -114,6 +114,9 @@ class SettingsActivity : AppCompatActivity() {
                 updateExportDirPreferenceSummary()
             }
 
+            findPreference<SwitchPreferenceCompat>("save_logcat")!!.summary =
+                getString(R.string.pref_save_logcat_desc, logcatFile(requireContext()))
+
             if (SDK_INT >= Build.VERSION_CODES.M) {
                 disableBattOptPreference.setOnPreferenceChangeListener { _, newValue ->
                     if (newValue == true) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,7 @@
     <string name="json_parse_error">Error parsing JSON file</string>
     <string name="missing_messages_ndjson_error">Can\'t find \'messages.ndjson\'. Please make sure that the provided file is a ZIP file in the correct format.</string>
     <string name="see_logcat">See logcat for more information.</string>
+    <string name="open_log_dir">Open log directory</string>
 
     <string name="sms_permissions_required">Exporting messages requires permission to read SMSs and contacts.</string>
     <string name="default_sms_app_requirement">This app must be the default SMS app to import or wipe messages.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,8 +59,11 @@
 
     <string name="json_parse_error">Error parsing JSON file</string>
     <string name="missing_messages_ndjson_error">Can\'t find \'messages.ndjson\'. Please make sure that the provided file is a ZIP file in the correct format.</string>
-    <string name="see_logcat">See logcat for more information.</string>
+    <string name="see_logcat_save_disabled">See logcat for more information. Enable \"Save logcat\" in the debug settings to automatically save the logcat to a file for future operations.</string>
+    <string name="see_logcat_save_enabled">See logcat in the log directory for more information.</string>
     <string name="open_log_dir">Open log directory</string>
+    <string name="pref_save_logcat_name">Save logcat</string>
+    <string name="pref_save_logcat_desc">Save logcat to %1$s when an operation is running.</string>
 
     <string name="sms_permissions_required">Exporting messages requires permission to read SMSs and contacts.</string>
     <string name="default_sms_app_requirement">This app must be the default SMS app to import or wipe messages.</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -120,6 +120,10 @@
     <PreferenceCategory android:title="Debugging options">
 
         <SwitchPreferenceCompat
+            android:key="save_logcat"
+            android:title="@string/pref_save_logcat_name" />
+
+        <SwitchPreferenceCompat
             android:key="debugging"
             android:title="Enable debugging options"
             app:defaultValue="false" />


### PR DESCRIPTION
(Please feel free to close this PR if you're not a fan of this approach or of this functionality in general.)

---

This updates the worker to spawn and kill logcat and the start and end of every operation. The output is written to sms-ie's external files directory (`/sdcard/Android/data/com.github.tmo1.sms_ie/files`), which is guaranteed to exist and be accessible using regular filesystem APIs. This is useful when an error is not easily reproducible and the user isn't able to get to their computer and grab a logcat via adb before the logs rotate.

When an error occurs, the error dialog has a new button to open the directory containing the log file in the system file manager (DocumentsUI). DocumentsUI and USB access are the only two ways to access the external files directory in newer versions of Android. However, DocumentsUI is full featured enough that the user can share the log file or copy it elsewhere.

The downside of these logs compared to `adb logcat` is that they will only contain our own logs. Logs from other apps or other system components (eg. telephony provider) are excluded.

<img width="200" alt="screenshot of new error dialog button" src="https://github.com/user-attachments/assets/36beea09-5729-4072-b74a-1d51e5289978" />
<img width="200" alt="screenshot of directory opened in DocumentsUI" src="https://github.com/user-attachments/assets/179213db-bcf8-4a12-853d-337272564e9c" />