### PR TITLE
Add full support for edge-to-edge

### DIFF
--- a/app/src/main/java/com/github/tmo1/sms_ie/AboutActivity.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/AboutActivity.kt
@@ -20,15 +20,31 @@
 
 package com.github.tmo1.sms_ie
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.widget.ScrollView
 import android.widget.TextView
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.updatePadding
 
 class AboutActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_about)
         val aboutText: TextView = findViewById(R.id.aboutText)
         aboutText.text = getString(R.string.app_about_text, BuildConfig.VERSION_NAME)
+
+        val scrollView: ScrollView = findViewById(R.id.about_content)
+        scrollView.clipToPadding = false
+
+        scrollView.avoidObstructions { insets ->
+            updatePadding(
+                left = insets.left,
+                top = insets.top,
+                right = insets.right,
+                bottom = insets.bottom,
+            )
+        }
     }
 }

--- a/app/src/main/java/com/github/tmo1/sms_ie/Insets.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/Insets.kt
@@ -1,0 +1,41 @@
+/*
+ * SMS Import / Export: a simple Android app for importing and exporting SMS messages from and to JSON files.
+ * Copyright (c) 2021-2025 Thomas More
+ *
+ * This file is part of SMS Import / Export.
+ *
+ * SMS Import / Export is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SMS Import / Export is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with SMS Import / Export.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.tmo1.sms_ie
+
+import android.view.View
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+// Helper function for implementing insets callbacks to change the view's margins or padding to
+// avoid obstructions, like the status bar, navigation bar, or physical notches.
+fun View.avoidObstructions(block: View.(Insets) -> Unit) {
+    ViewCompat.setOnApplyWindowInsetsListener(this) { v, windowInsets ->
+        val insets = windowInsets.getInsets(
+            WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout()
+        )
+
+        block(insets)
+
+        windowInsets
+    }
+}

--- a/app/src/main/java/com/github/tmo1/sms_ie/MainActivity.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/MainActivity.kt
@@ -40,13 +40,19 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ProgressBar
+import android.widget.ScrollView
 import android.widget.TextView
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Observer
 import androidx.preference.PreferenceManager
@@ -131,6 +137,12 @@ class MainActivity : AppCompatActivity(), ConfirmWipeFragment.NoticeDialogListen
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Let the app draw under the status bar. The appcompat library figures out what needs to be
+        // done to prevent the app from shifting up. Edge-to-edge is required for
+        // android:windowLightStatusBar in themes.xml to work so that light text isn't used on a
+        // light status bar.
+        enableEdgeToEdge()
+
         super.onCreate(savedInstanceState)
 
         if (savedInstanceState != null) {
@@ -159,7 +171,30 @@ class MainActivity : AppCompatActivity(), ConfirmWipeFragment.NoticeDialogListen
 
         // set up UI
         setContentView(R.layout.activity_main)
-        setSupportActionBar(findViewById(R.id.toolbar))
+
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        toolbar.avoidObstructions { insets ->
+            // Shift the toolbar down using margins, but use padding for the sides. When the phone
+            // is in landscape and the phone has a notch, it looks nicer to have the bar's
+            // background extend horizontally fully.
+            updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                topMargin = insets.top
+            }
+            updatePadding(
+                left = insets.left,
+                right = insets.right,
+            )
+        }
+        setSupportActionBar(toolbar)
+
+        findViewById<ScrollView>(R.id.main_content).avoidObstructions { insets ->
+            updatePadding(
+                left = insets.left,
+                right = insets.right,
+                bottom = insets.bottom,
+            )
+        }
+
         val exportMessagesButton: Button = findViewById(R.id.export_messages_button)
         val exportCallLogButton: Button = findViewById(R.id.export_call_log_button)
         val importMessagesButton: Button = findViewById(R.id.import_messages_button)

--- a/app/src/main/java/com/github/tmo1/sms_ie/SettingsActivity.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/SettingsActivity.kt
@@ -34,14 +34,21 @@ import android.os.Bundle
 import android.os.PowerManager
 import android.provider.Settings
 import android.util.Log
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
+import androidx.recyclerview.widget.RecyclerView
 
 const val REQUEST_EXPORT_FOLDER = 4
 const val EXPORT_DIR = "export_dir"
@@ -51,15 +58,33 @@ class SettingsActivity : AppCompatActivity() {
 
     //private lateinit var prefs: SharedPreferences
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.settings_activity)
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction().replace(R.id.settings, SettingsFragment())
                 .commit()
         }
-        //supportActionBar?.setDisplayHomeAsUpEnabled(true)
-        //setSupportActionBar(findViewById(R.id.toolbar))
+
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        toolbar.avoidObstructions { insets ->
+            // Shift the toolbar down using margins, but use padding for the sides. When the phone
+            // is in landscape and the phone has a notch, it looks nicer to have the bar's
+            // background extend horizontally fully.
+            updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                topMargin = insets.top
+            }
+            updatePadding(
+                left = insets.left,
+                right = insets.right,
+            )
+        }
+
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
         //prefs = PreferenceManager.getDefaultSharedPreferences(this)
+
+        setTitle(R.string.settings)
     }
 
     class SettingsFragment : PreferenceFragmentCompat() {
@@ -85,6 +110,29 @@ class SettingsActivity : AppCompatActivity() {
             } else {
                 Log.d("Permission: ", "Denied")
             }
+        }
+
+        override fun onCreateRecyclerView(
+            inflater: LayoutInflater,
+            parent: ViewGroup,
+            savedInstanceState: Bundle?
+        ): RecyclerView {
+            val view = super.onCreateRecyclerView(inflater, parent, savedInstanceState)
+
+            // Since we're edge-to-edge, preference options further down can be drawn under the
+            // translucent navigation bar. Make sure the RecyclerView leaves padding at the end so
+            // that the final setting is tappable when the user scrolls to the bottom.
+            view.clipToPadding = false
+
+            view.avoidObstructions { insets ->
+                updatePadding(
+                    bottom = insets.bottom,
+                    left = insets.left,
+                    right = insets.right,
+                )
+            }
+
+            return view
         }
 
         @SuppressLint("BatteryLife")

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -21,14 +21,14 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/about_content"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".AboutActivity">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
+        android:layout_height="wrap_content">
 
         <TextView
             android:id="@+id/aboutText"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,30 +21,32 @@
   ~ along with SMS Import / Export.  If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fillViewport="true"
-    android:fadeScrollbars="false"
+    android:orientation="vertical"
     tools:context=".MainActivity">
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorPrimary"
         android:minHeight="?attr/actionBarSize"
-        android:theme="?attr/actionBarTheme"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:theme="?attr/actionBarTheme" />
+
+    <ScrollView
+        android:id="@+id/main_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true"
+        android:fadeScrollbars="false">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
     <Button
         android:id="@+id/export_messages_button"
@@ -55,7 +57,7 @@
         app:layout_constraintEnd_toStartOf="@+id/import_messages_button"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/import_messages_button"
@@ -66,7 +68,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/export_messages_button"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/export_call_log_button"
@@ -193,5 +195,5 @@
         app:layout_constraintTop_toBottomOf="@+id/default_sms_app_warning" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-</ScrollView>
+    </ScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/settings_activity.xml
+++ b/app/src/main/res/layout/settings_activity.xml
@@ -20,7 +20,16 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="?attr/actionBarTheme" />
 
     <FrameLayout
         android:id="@+id/settings"

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -31,6 +31,7 @@
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="23">false</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -31,6 +31,7 @@
         <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="android:windowLightStatusBar" tools:targetApi="23">true</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>


### PR DESCRIPTION
This commit replaces the use of `android:fitsSystemWindows` with inset callbacks to fully implement support for edge-to-edge introduced in API 35. While this makes the code a bit more verbose, this fixes a few UI-related bugs and quirks:

* The top and bottom of the list of settings no longer get "stuck" behind the status and navigation bars.
* The side of the list of settings no longer overlaps the physical notch on phones.
* The status bar, in light mode, no longer shows white text on a white background. This is not easily fixable without edge-to-edge support and was the main reason for implementing this change.

This commit also includes a couple minor toolbar changes:

* MainActivity's toolbar now stays locked in place instead of scrolling off screen on smaller devices.
* SettingsActivity now shows a toolbar for consistency with MainActivity.

---

The changes are most visible on API 35 and 36 devices. These are screenshots from my Pixel 9 Pro XL:

### API 36 - Main activity - Before and after

Changes:
* The button proportions changed slightly because they use ConstraintLayout based on percentages and the toolbar is now always pinned to the top (doesn't scroll with the content on small screens).
* The light theme status bar text is no longer white-on-white.
* The toolbar is no longer cut off when the device has a physical notch.

<details>
<summary>Screenshots (click to expand):</summary>

<img width="100" alt="api_36_main_portrait_light_before" src="https://github.com/user-attachments/assets/28366535-65b0-497a-bdb1-c1716a949aee" />
<img width="100" alt="api_36_main_portrait_light_after" src="https://github.com/user-attachments/assets/bfc0cd4f-2743-49c5-9e89-ccd7c09b07a8" />

<br />

<img width="100" alt="api_36_main_portrait_dark_before" src="https://github.com/user-attachments/assets/eb23beaa-8ef8-46a3-a433-1025d17d9a06" />
<img width="100" alt="api_36_main_portrait_dark_after" src="https://github.com/user-attachments/assets/d17ac1e7-fc9a-4cd1-9b91-f516dc6d96a8" />

<br />

<img height="100" alt="api_36_main_landscape_light_before" src="https://github.com/user-attachments/assets/e0d11ba4-c4ad-41a1-a465-48ae23f9d602" />
<img height="100" alt="api_36_main_landscape_light_after" src="https://github.com/user-attachments/assets/1168b8c9-bf5a-4a78-9b7c-cd299f40c432" />

<br />

<img height="100" alt="api_36_main_landscape_dark_before" src="https://github.com/user-attachments/assets/0d1442e1-11dd-46ab-b4b4-d50c40603960" />
<img height="100" alt="api_36_main_landscape_dark_after" src="https://github.com/user-attachments/assets/5966e7ae-548d-4423-af5d-8c7a0789fbf4" />

</details>

### API 36 - Settings activity - Before and after

Changes:
* The top setting is no longer covered by the status bar and the bottom setting (after scrolling to the bottom) is no longer covered by the navigation bar.
* The sides of the settings no longer overlap the notch.
* The light theme status bar text is no longer white-on-white.
* There is now a toolbar.

<details>
<summary>Screenshots (click to expand):</summary>

<img width="100" alt="api_36_settings_portrait_light_before" src="https://github.com/user-attachments/assets/45d8f81e-50a0-4d0c-a388-0a2068dc22e9" />
<img width="100" alt="api_36_settings_portrait_light_after" src="https://github.com/user-attachments/assets/51d1e0b0-95bd-4eb3-9fda-def137a58a2b" />

<br />

<img width="100" alt="api_36_settings_portrait_dark_before" src="https://github.com/user-attachments/assets/283dc0d5-dfa7-4db3-9151-42fea707d420" />
<img width="100" alt="api_36_settings_portrait_dark_after" src="https://github.com/user-attachments/assets/1e454bab-3324-4bfc-954b-fdd61675a6f4" />

<br />

<img height="100" alt="api_36_settings_landscape_light_before" src="https://github.com/user-attachments/assets/273ffd5f-4798-455b-8e0a-136f469ba728" />
<img height="100" alt="api_36_settings_landscape_light_after" src="https://github.com/user-attachments/assets/770cb1fa-ad2a-4fbf-9a58-f83d1dd3c211" />

<br />

<img height="100" alt="api_36_settings_landscape_dark_before" src="https://github.com/user-attachments/assets/2b2fe0f7-6618-4b56-8c12-7ece00fd221d" />
<img height="100" alt="api_36_settings_landscape_dark_after" src="https://github.com/user-attachments/assets/4cbab111-4179-4615-8273-c54e02e51180" />

</details>

### API 36 - About activity - Before and after

Changes:
* The light theme status bar text is no longer white-on-white.
* (Dark theme is identical.)

<details>
<summary>Screenshots (click to expand):</summary>

<img width="100" alt="api_36_about_portrait_light_before" src="https://github.com/user-attachments/assets/d5cdbc44-0be5-4dac-b8e4-2fe244d024b9" />
<img width="100" alt="api_36_about_portrait_light_after" src="https://github.com/user-attachments/assets/e7766e47-68c1-4fe6-9a81-b1a19e313045" />

<br />

<img width="100" alt="api_36_about_portrait_dark_before" src="https://github.com/user-attachments/assets/3ff2b55d-f6ec-4f6f-acc0-444bb943dff1" />
<img width="100" alt="api_36_about_portrait_dark_after" src="https://github.com/user-attachments/assets/11727c68-2430-4875-8a72-53f2ce8cb68c" />

<br />

<img height="100" alt="api_36_about_landscape_light_before" src="https://github.com/user-attachments/assets/1d09edc0-b4b4-42a4-a9ab-0b71771a48d9" />
<img height="100" alt="api_36_about_landscape_light_after" src="https://github.com/user-attachments/assets/42670801-0fcf-44ae-8fcc-6b3f8fa03cf1" />

<br />

<img height="100" alt="api_36_about_landscape_dark_before" src="https://github.com/user-attachments/assets/384e55a5-d361-40dd-8180-a61a17c3ae1e" />
<img height="100" alt="api_36_about_landscape_dark_after" src="https://github.com/user-attachments/assets/2d737ddd-9ea2-432b-8226-dee6610c92ea" />

</details>

---

I'm always terrified of making UI changes in case they break in older versions of Android. Since the androidx appcompat library has different implementations of `enableEdgeToEdge()` for API <21, 21, 23, 26, and 29, I tested each of those versions. I didn't do a before/after comparison here. I only checked to make sure nothing looked wrong or ugly.

### API 19

<details>
<summary>Screenshots (click to expand):</summary>

<img width="100" alt="api_19_main_portrait" src="https://github.com/user-attachments/assets/4cf21788-55e6-4781-b623-79296705edbc" />
<img height="100" alt="api_19_main_landscape" src="https://github.com/user-attachments/assets/227a0248-eff2-400d-8fb8-aaa2ec196905" />

<br />

<img width="100" alt="api_19_settings_portrait" src="https://github.com/user-attachments/assets/6756cf14-a877-478d-93e8-ac152cd0425f" />
<img height="100" alt="api_19_settings_landscape" src="https://github.com/user-attachments/assets/bd26a863-74a6-4e3a-91ea-6b81a842c5f5" />

<br />

<img width="100" alt="api_19_about_portrait" src="https://github.com/user-attachments/assets/55d79088-6498-40f3-a173-8ad27d122b17" />
<img height="100" alt="api_19_about_landscape" src="https://github.com/user-attachments/assets/d5b2c570-0a3d-4f1a-8ff0-30c18ba86ad0" />

</details>

### API 21

<details>
<summary>Screenshots (click to expand):</summary>

<img width="100" alt="api_21_main_portrait" src="https://github.com/user-attachments/assets/82f70c2d-cc1f-4c48-928a-c14e1513198d" />
<img height="100" alt="api_21_main_landscape" src="https://github.com/user-attachments/assets/a2a42b3c-8dc4-42fb-9994-c82017f9f95a" />

<br />

<img width="100" alt="api_21_settings_portrait" src="https://github.com/user-attachments/assets/38915909-2227-44bc-8dcf-9b431625ab25" />
<img height="100" alt="api_21_settings_landscape" src="https://github.com/user-attachments/assets/0de42d49-0662-4bfa-b981-bf30136dbf85" />

<br />

<img width="100" alt="api_21_about_portrait" src="https://github.com/user-attachments/assets/c38d8a4a-07e5-425a-bccf-7c9acffb157e" />
<img height="100" alt="api_21_about_landscape" src="https://github.com/user-attachments/assets/6b737c5c-b605-49ae-84b1-c24596d272ca" />

</details>

### API 23

<details>
<summary>Screenshots (click to expand):</summary>

<img width="100" alt="api_23_main_portrait" src="https://github.com/user-attachments/assets/bcf8258f-54ac-45bc-a736-c2df8d9527c5" />
<img height="100" alt="api_23_main_landscape" src="https://github.com/user-attachments/assets/e8e8d79a-905f-4e54-b3a1-d42a11d38bce" />

<br />

<img width="100" alt="api_23_settings_portrait" src="https://github.com/user-attachments/assets/12648984-1427-48b5-aca5-3fd541a39bae" />
<img height="100" alt="api_23_settings_landscape" src="https://github.com/user-attachments/assets/8023c743-b40a-4a56-ad54-4c1c6021b8a9" />

<br />

<img width="100" alt="api_23_about_portrait" src="https://github.com/user-attachments/assets/22709b8e-cd08-4319-a10c-a53367ed49cf" />
<img height="100" alt="api_23_about_landscape" src="https://github.com/user-attachments/assets/94246d40-6c4d-4157-ae76-4c4efcdefa24" />

</details>

### API 26

<details>
<summary>Screenshots (click to expand):</summary>

<img width="100" alt="api_26_main_portrait" src="https://github.com/user-attachments/assets/e76d31cc-0468-4231-94df-94297981b3d0" />
<img height="100" alt="api_26_main_landscape" src="https://github.com/user-attachments/assets/dd8124c3-8eeb-4746-bfca-3f2bd2ec608c" />

<br />

<img width="100" alt="api_26_settings_portrait" src="https://github.com/user-attachments/assets/c4cfee6a-a0ad-4b21-94af-d02de5802845" />
<img height="100" alt="api_26_settings_landscape" src="https://github.com/user-attachments/assets/4622cd6c-6e30-4265-9467-3e8373686886" />

<br />

<img width="100" alt="api_26_about_portrait" src="https://github.com/user-attachments/assets/0ee59e21-9ca9-48ed-a158-500918961ba2" />
<img height="100" alt="api_26_about_landscape" src="https://github.com/user-attachments/assets/2d827dcc-538e-471e-8e5d-7a88c9d43b5a" />

</details>

### API 29

<details>
<summary>Screenshots (click to expand):</summary>

<img width="100" alt="api_29_main_portrait" src="https://github.com/user-attachments/assets/efb079e8-5665-434c-9cf6-510fe0323b68" />
<img height="100" alt="api_29_main_landscape" src="https://github.com/user-attachments/assets/7901f91f-4005-493a-a4c5-fe9ba06757ad" />

<br />

<img width="100" alt="api_29_settings_portrait" src="https://github.com/user-attachments/assets/1c71d3ad-3efb-451d-8050-c02c3f6ce225" />
<img height="100" alt="api_29_settings_landscape" src="https://github.com/user-attachments/assets/92e94cf8-1ebf-41a3-9607-8ad88f713d57" />

<br />

<img width="100" alt="api_29_about_portrait" src="https://github.com/user-attachments/assets/2aa134cd-a54d-4816-886d-6ce73dc128b2" />
<img height="100" alt="api_29_about_landscape" src="https://github.com/user-attachments/assets/36183f3c-4d7c-44af-9df8-151a312e0bb8" />

</details>