### PR TITLE
Only allow background services notifications to alert once

### DIFF
--- a/app/src/main/java/com/github/tmo1/sms_ie/ImportExportWorker.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/ImportExportWorker.kt
@@ -233,6 +233,9 @@ class ImportExportWorker(appContext: Context, workerParams: WorkerParameters) :
                 .setStyle(NotificationCompat.BigTextStyle())
                 .setProgress(progress.total, progress.current, progress.total == 0)
                 .setOngoing(true)
+                // Ensure that the device won't vibrate or make a notification sound every time the
+                // progress is updated.
+                .setOnlyAlertOnce(true)
                 .apply {
                     // Inhibit 10-second delay when showing persistent notification
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/app/src/main/java/com/github/tmo1/sms_ie/MainActivity.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/MainActivity.kt
@@ -203,7 +203,7 @@ class MainActivity : AppCompatActivity(), ConfirmWipeFragment.NoticeDialogListen
                 NotificationChannel(
                     CHANNEL_ID_PERSISTENT,
                     getString(R.string.persistent_channel_name),
-                    NotificationManager.IMPORTANCE_DEFAULT
+                    NotificationManager.IMPORTANCE_LOW
                 ).apply {
                     description = getString(R.string.persistent_channel_description)
                 }


### PR DESCRIPTION
This fixes the device playing the notification source or vibrating every time the notification is updated (for progress bar changes). I didn't catch this when implementing #268 because I had a Pixel Watch connected, which always forces the `setOnlyAlertOnce(true)` behavior.

Additionally, this changes the default importance of the background services notifications to low (referred to as "Silent" in Android's UI). Even with the original bug fixed, it doesn't make much sense to play a sound or vibrate one time when an operation starts. This change in defaults only takes effect for new installs. It is not possible to change existing notification channel settings.

Fixes: #276