### PR TITLE
ImportExportContacts: Fix JSON nesting IllegalStateException

### DIFF
--- a/app/src/main/java/com/github/tmo1/sms_ie/ImportExportContacts.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/ImportExportContacts.kt
@@ -148,9 +148,9 @@ private suspend fun contactsToJSON(
                                         }
                                         jsonWriter.endObject()
                                     } while (data.moveToNext())
+                                    jsonWriter.endArray()
                                 }
                             }
-                            jsonWriter.endArray()
                             jsonWriter.endObject()
                         } while (raw.moveToNext())
                         jsonWriter.endArray()


### PR DESCRIPTION
When exporting contacts, if querying `ContactsContract.Data.CONTENT_URI` returns no data, then we previously tried to end a JSON array that was never started.

Fixes: #280