### PR TITLE
MessageFiltersActivity: Enable edge-to-edge and remove editbox_background

### DIFF
--- a/app/src/main/java/com/github/tmo1/sms_ie/MessageFiltersActivity.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/MessageFiltersActivity.kt
@@ -35,6 +35,7 @@ import android.widget.EditText
 import android.widget.ListView
 import android.widget.Spinner
 import android.widget.TextView
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SwitchCompat
@@ -52,6 +53,7 @@ const val MMS = 1
 class MessageFiltersActivity : AppCompatActivity() {
     val list = arrayListOf<MessageFilter>()
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         // https://developer.android.com/guide/fragments/communicate#fragment-result
         val prefs = PreferenceManager.getDefaultSharedPreferences(this)

--- a/app/src/main/res/drawable/view_border.xml
+++ b/app/src/main/res/drawable/view_border.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <stroke
+        android:width="1dp"
+        android:color="@android:color/tab_indicator_text" />
+</shape>

--- a/app/src/main/res/layout/activity_message_filters.xml
+++ b/app/src/main/res/layout/activity_message_filters.xml
@@ -53,7 +53,6 @@
             android:id="@+id/message_filters_list"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:background="@android:drawable/editbox_background"
             app:layout_constraintBottom_toTopOf="@+id/tap_filter_to_edit_or_delete"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/add_message_filter.xml
+++ b/app/src/main/res/layout/add_message_filter.xml
@@ -32,8 +32,7 @@
         <Spinner
             android:id="@+id/message_column_name"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@android:drawable/editbox_background" />
+            android:layout_height="wrap_content" />
     </TableRow>
 
     <TableRow>
@@ -46,8 +45,7 @@
         <Spinner
             android:id="@+id/operator"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@android:drawable/editbox_background" />
+            android:layout_height="wrap_content" />
     </TableRow>
 
     <TableRow>
@@ -61,7 +59,6 @@
             android:id="@+id/message_column_value"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:background="@android:drawable/editbox_background"
             android:hint="@string/value"
             android:importantForAutofill="no"
             android:inputType="text" />

--- a/app/src/main/res/layout/add_message_filter.xml
+++ b/app/src/main/res/layout/add_message_filter.xml
@@ -36,10 +36,15 @@
             android:layout_height="wrap_content"
             android:text="@string/column_name" />
 
-        <Spinner
-            android:id="@+id/message_column_name"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+        <FrameLayout
+            android:background="@drawable/view_border"
+            android:layout_margin="2dp">
+            <Spinner
+                android:id="@+id/message_column_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="36dp" />
+        </FrameLayout>
     </TableRow>
 
     <TableRow
@@ -51,10 +56,15 @@
             android:layout_height="wrap_content"
             android:text="@string/operator" />
 
-        <Spinner
-            android:id="@+id/operator"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+        <FrameLayout
+            android:background="@drawable/view_border"
+            android:layout_margin="2dp">
+            <Spinner
+                android:id="@+id/operator"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="36dp" />
+        </FrameLayout>
     </TableRow>
 
     <TableRow
@@ -66,13 +76,23 @@
             android:layout_height="wrap_content"
             android:text="@string/column_value" />
 
-        <EditText
-            android:id="@+id/message_column_value"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/value"
-            android:importantForAutofill="no"
-            android:inputType="text" />
+        <FrameLayout
+            android:background="@drawable/view_border"
+            android:layout_margin="2dp">
+            <!-- Intentionally styled to look like the spinners above. -->
+            <EditText
+                android:id="@+id/message_column_value"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="8dp"
+                android:paddingEnd="8dp"
+                android:background="@null"
+                android:minHeight="36dp"
+                android:textSize="16sp"
+                android:hint="@string/value"
+                android:importantForAutofill="no"
+                android:inputType="text" />
+        </FrameLayout>
     </TableRow>
 
     <TableRow

--- a/app/src/main/res/layout/add_message_filter.xml
+++ b/app/src/main/res/layout/add_message_filter.xml
@@ -19,10 +19,17 @@
   -->
 
 <TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:stretchColumns="1"
+    android:measureWithLargestChild="true"
+    android:paddingStart="?attr/dialogPreferredPadding"
+    android:paddingEnd="?attr/dialogPreferredPadding"
+    android:paddingTop="?attr/dialogPreferredPadding">
 
-    <TableRow>
+    <TableRow
+        android:layout_weight="1"
+        android:gravity="center_vertical">
 
         <TextView
             android:layout_width="wrap_content"
@@ -31,11 +38,13 @@
 
         <Spinner
             android:id="@+id/message_column_name"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content" />
     </TableRow>
 
-    <TableRow>
+    <TableRow
+        android:layout_weight="1"
+        android:gravity="center_vertical">
 
         <TextView
             android:layout_width="wrap_content"
@@ -44,11 +53,13 @@
 
         <Spinner
             android:id="@+id/operator"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content" />
     </TableRow>
 
-    <TableRow>
+    <TableRow
+        android:layout_weight="1"
+        android:gravity="center_vertical">
 
         <TextView
             android:layout_width="wrap_content"
@@ -57,14 +68,16 @@
 
         <EditText
             android:id="@+id/message_column_value"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/value"
             android:importantForAutofill="no"
             android:inputType="text" />
     </TableRow>
 
-    <TableRow>
+    <TableRow
+        android:layout_weight="1"
+        android:gravity="center_vertical">
 
         <TextView
             android:layout_width="wrap_content"
@@ -75,7 +88,7 @@
             android:id="@+id/filter_active"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
+            android:layout_gravity="center"
             android:checked="true" />
     </TableRow>
 </TableLayout>


### PR DESCRIPTION
* Fixes the status bar having light text on a light background when the OS is set to light mode.
* Fixes spinners having light text on a light background when the OS is set to dark mode. (`@android:drawable/editbox_background` is not day/night-aware.)
  * NOTE: This does change how the UI looks a little bit. If this is not desired, I can try to find a different approach.

Fixes: #304