### PR TITLE
ImportExportWorker: Retry throttled notifications when idle

### DIFF
--- a/app/src/main/java/com/github/tmo1/sms_ie/ImportExportWorker.kt
+++ b/app/src/main/java/com/github/tmo1/sms_ie/ImportExportWorker.kt
@@ -50,7 +50,13 @@ import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.io.File
@@ -133,8 +139,14 @@ class ImportExportWorker(appContext: Context, workerParams: WorkerParameters) :
     private var notifyViaForeground = true
 
     // Avoid updating the notification too frequently or else Android will rate limit us and block
-    // any notification from being sent.
+    // any notification from being sent. Note that the notification will never be stuck showing an
+    // old status for a long time. If the latest progress update couldn't be shown because of
+    // throttling, then foregroundDelayedRetry will be scheduled to retry sending the notification
+    // 1 second later.
     private var foregroundLastTimestamp = 0L
+    private var foregroundProgress = Progress(0, 0, null)
+    private var foregroundDelayedRetry: Job? = null
+    private val foregroundLock = Mutex()
 
     private suspend fun updateProgress(progress: Progress) {
         // [Unthrottled] For updating MainActivity and anything else that might be monitoring this
@@ -143,13 +155,16 @@ class ImportExportWorker(appContext: Context, workerParams: WorkerParameters) :
         // MainActivity has no other way to know if this is cancellable.
         setProgress(progress.copy(canCancel = action.isCancellable).toWorkData())
         // [Throttled] For updating the foreground service notification.
-        refreshForegroundNotification(progress)
+        foregroundLock.withLock {
+            foregroundProgress = progress
+            refreshForegroundNotificationLocked()
+        }
     }
 
     override suspend fun doWork(): Result = GLOBAL_LOCK.withLock {
         val context = applicationContext
 
-        refreshForegroundNotification(Progress(0, 0, null))
+        updateProgress(Progress(0, 0, null))
 
         // Redirecting stdout is better than using -f because the logcat implementation calls
         // fflush() only when outputting to stdout. When using -f, interrupting logcat may mean that
@@ -222,6 +237,12 @@ class ImportExportWorker(appContext: Context, workerParams: WorkerParameters) :
             if (action == Action.EXPORT_AUTOMATIC) {
                 scheduleAutomaticExport(context, false)
             }
+        }
+
+        // Cancel the pending retry for a throttled notification update because the work is complete
+        // and the notification is about to be dismissed anyway.
+        foregroundLock.withLock {
+            cancelForegroundNotificationDelayedLocked()
         }
 
         // There are two scenarios where we need to manually dismiss the notification:
@@ -308,19 +329,55 @@ class ImportExportWorker(appContext: Context, workerParams: WorkerParameters) :
             }.build()
     }
 
-    private suspend fun refreshForegroundNotification(progress: Progress) {
+    private suspend fun refreshForegroundNotificationDelayed() {
+        try {
+            delay(1_000)
+
+            foregroundLock.withLock {
+                foregroundDelayedRetry = null
+                refreshForegroundNotificationLocked()
+            }
+        } catch (_: CancellationException) {
+            // Cancelled either by refreshForegroundNotificationLocked() because a newer
+            // notification could be shown in the meantime or by doWork() because the work is
+            // complete.
+        }
+    }
+
+    private suspend fun cancelForegroundNotificationDelayedLocked() {
+        foregroundDelayedRetry?.let { job ->
+            job.cancelAndJoin()
+            foregroundDelayedRetry = null
+        }
+    }
+
+    private suspend fun refreshForegroundNotificationLocked() {
         // Throttle to 1 update per second to avoid hitting Android's rate limits.
         val now = System.nanoTime()
         if (now - foregroundLastTimestamp < 1_000_000_000) {
+            // We still need to try again later. Otherwise, longer-running actions that don't
+            // provide progress updates, like "Copying MMS binary data …", never get a chance to
+            // have their notification shown if their initial notification got throttled.
+            if (foregroundDelayedRetry == null) {
+                // Don't overwrite a pre-existing retry that was scheduled earlier.
+                foregroundDelayedRetry = CoroutineScope(currentCoroutineContext()).launch {
+                    refreshForegroundNotificationDelayed()
+                }
+            }
+
             return
         }
         foregroundLastTimestamp = now
+
+        // We're about to show the latest update. There's no need for any previously scheduled
+        // retries anymore.
+        cancelForegroundNotificationDelayedLocked()
 
         // Android 14 introduced a new battery optimization that will kill apps that perform too
         // many binder transactions in the background, which can happen when exporting many
         // messages. Running the service in the foreground prevents the app from being killed.
         // https://android.googlesource.com/platform/frameworks/base.git/+/71d75c09b9a06732a6edb4d1488d2aa3eb779e14%5E%21/
-        notification = createForegroundNotification(progress)
+        notification = createForegroundNotification(foregroundProgress)
 
         try {
             if (notifyViaForeground) {


### PR DESCRIPTION
This fixes an issue where notifications that change infrequently are sometimes never shown.

This most commonly happens at the end of the MMS export. If the last "X of Y MMS(s) exported" text was shown less than 1 second ago, then the throttling prevents "Copying MMS binary data …" from being shown when that operation begins. However, since the MMS binary data export does not have progress updates, missing the initial notification means it never gets the chance to be shown at all.

This commit fixes the problem by introducing an automatic retry mechanism. If the latest notification got throttled, then it will retry 1 second later as long as no further (unthrottled) progress updates have happened in the meantime.