### PR TITLE
Add r8/proguard rules for JNA

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -30,3 +30,8 @@
   static *** isLoggable(...);
 }
 
+# From https://github.com/java-native-access/jna/blob/master/www/FrequentlyAskedQuestions.md#jna-on-android
+-dontwarn java.awt.*
+-keep class com.sun.jna.* { *; }
+-keep class * extends com.sun.jna.* { *; }
+-keepclassmembers class * extends com.sun.jna.* { public *; }


### PR DESCRIPTION
JNA's Android `.aar` artifact doesn't include any r8/proguard rules. According to their FAQ [1], application developers are expected to copy and paste the 4 rules into their proguard configs. Without these rules, `SodiumAndroid()` initialization would fail because JNA's initialization can't find the fields it needed via reflection with r8 renaming fields to single letter names.

    java.lang.UnsatisfiedLinkError: Can't obtain peer field ID for class com.sun.jna.Pointer

This only affected release builds since debug builds don't have r8 enabled.

[1] https://github.com/java-native-access/jna/blob/master/www/FrequentlyAskedQuestions.md#jna-on-android

Fixes: #357